### PR TITLE
Test/suite 🔢

### DIFF
--- a/scripts/cycle.ts
+++ b/scripts/cycle.ts
@@ -82,13 +82,13 @@ async function main() {
 
   // Dump account balances
   const deployerBal = await ethers.provider.getBalance(deployAdr);
-  console.log("\n******** Deployer Balance", ethers.utils.formatEther(deployerBal));
+  console.log("\n******** Deployer Balance", deployAdr, ethers.utils.formatEther(deployerBal));
   const adminBal = await ethers.provider.getBalance(adminAdr);
-  console.log("\n******** Admin Balance", ethers.utils.formatEther(adminBal));
+  console.log("\n******** Admin Balance", adminAdr, ethers.utils.formatEther(adminBal));
   const bobBal = await ethers.provider.getBalance(bobAdr);
-  console.log("\n******** Bob Balance", ethers.utils.formatEther(bobBal));
+  console.log("\n******** Bob Balance", bobAdr, ethers.utils.formatEther(bobBal));
   const aliceBal = await ethers.provider.getBalance(aliceAdr);
-  console.log("\n******** Alice Balance", ethers.utils.formatEther(aliceBal));
+  console.log("\n******** Alice Balance", aliceAdr, ethers.utils.formatEther(aliceBal));
 }
 
 main()

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -6,15 +6,23 @@ async function main() {
   const admin = ethers.provider.getSigner(1);
   const adminAdr = await admin.getAddress();
 
-  console.log(adminAdr)
+  console.log("Admin Address:", adminAdr)
 
   const name = "LoreumNFT";
   const symbol = "LOREUM";
   const tokenUri = "ipfs://bafybeia4ba2mxk3dzdhu2kaqeh5svu244qmcwbkhm56e2nz4pnuqfake4q/";
-  const mintCost = ethers.BigNumber.from("5").pow(16);
+  const mintCost = ethers.BigNumber.from("10").pow(16).mul(5)
   const royaltyFraction = 500;
   const maxSupply = 10000;
   const maxMint = 100;
+
+  console.log("Name:", name);
+  console.log("Symbol:", symbol);
+  console.log("Token URI:", tokenUri);
+  console.log("Mint Cost:", ethers.utils.formatEther(mintCost.toString()), "ether");
+  console.log("Royalty Fraction:", royaltyFraction);
+  console.log("Max Supply:", maxSupply);
+  console.log("Max Mint per Wallet:", maxMint);
 
   const LoreumNFT = await ethers.getContractFactory(name);
   const NFT = await LoreumNFT.deploy(
@@ -29,7 +37,7 @@ async function main() {
   );
 
   await NFT.deployed();
-  console.log(NFT.address);
+  console.log("NFT Contract:", NFT.address);
 }
 
 main()

--- a/src/LoreumNFT.sol
+++ b/src/LoreumNFT.sol
@@ -5,11 +5,12 @@ import "open-zeppelin/contracts/token/common/ERC2981.sol";
 import "open-zeppelin/contracts/utils/introspection/ERC165Storage.sol";
 
 import "open-zeppelin/contracts/access/Ownable.sol";
+import "open-zeppelin/contracts/security/ReentrancyGuard.sol";
 import "open-zeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "open-zeppelin/contracts/utils/Strings.sol";
 
 /// @title The base NFT contract for the Loreum collection.
-contract LoreumNFT is ERC165Storage, ERC2981, ERC721Enumerable, Ownable {
+contract LoreumNFT is ERC165Storage, ERC2981, ERC721Enumerable, Ownable, ReentrancyGuard {
 
     // ---------------------
     //    State Variables
@@ -129,7 +130,7 @@ contract LoreumNFT is ERC165Storage, ERC2981, ERC721Enumerable, Ownable {
 
     /// @notice A public endpoint to mint an NFT, allows for batch minting.
     /// @param  amount The amount of NFTs to mint.
-    function publicMint(uint8 amount) external payable {
+    function publicMint(uint8 amount) external payable nonReentrant {
         require(msg.value == amount * mintCost, "LoreumNFT::publicMint() msg.value != amount * mintCost");
         require(
             amount > 0 && amount + totalMinted[_msgSender()] <= MAX_MINT, 

--- a/src/LoreumNFT.sol
+++ b/src/LoreumNFT.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.16;
 
 import "open-zeppelin/contracts/token/common/ERC2981.sol";
@@ -108,7 +108,7 @@ contract LoreumNFT is ERC165Storage, ERC2981, ERC721Enumerable, Ownable {
     /// @notice Transfers ownership of the contract to a new account (`newOwner`) and updates defaultyRoyalty info.
     /// @dev    Can only be called by the current owner.
     function transferOwnership(address newOwner) public override(Ownable) onlyOwner {
-        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        require(newOwner != address(0), "LoreumNFT::transferOwnership() newOwner == address(0)");
         _transferOwnership(newOwner);
         _setDefaultRoyalty(newOwner, royaltyFraction);
     }
@@ -130,14 +130,14 @@ contract LoreumNFT is ERC165Storage, ERC2981, ERC721Enumerable, Ownable {
     /// @notice A public endpoint to mint an NFT, allows for batch minting.
     /// @param  amount The amount of NFTs to mint.
     function publicMint(uint8 amount) external payable {
-        require(msg.value == amount * mintCost, "Minter::publicMint() msg.value != amount * mintCost");
+        require(msg.value == amount * mintCost, "LoreumNFT::publicMint() msg.value != amount * mintCost");
         require(
             amount > 0 && amount + totalMinted[_msgSender()] <= MAX_MINT, 
-            "Minter::publicMint() amount == 0 || amount + totalMinted[_msgSender()] > MAX_MINT"
+            "LoreumNFT::publicMint() amount == 0 || amount + totalMinted[_msgSender()] > MAX_MINT"
         );
         require(
             totalSupply() < MAX_SUPPLY && totalSupply() + amount <= MAX_SUPPLY, 
-            "Minter::publicMint() minted >= MAX_SUPPLY || minted + amount > MAX_SUPPLY"
+            "LoreumNFT::publicMint() minted >= MAX_SUPPLY || minted + amount > MAX_SUPPLY"
         );
         
         // Increment amount of NFTs minted by _msgSender().

--- a/test/LoreumNFT.t.sol
+++ b/test/LoreumNFT.t.sol
@@ -177,10 +177,6 @@ contract LoreumNFTTest is Utility, ERC721Holder {
         // LoreumNFT::publicMint() amount + totalMinted[_msgSender()] > MAX_MINT
         payment = NFT.mintCost() * (NFT.MAX_MINT() + 1);
         assert(!ass.try_publicMint(address(NFT), NFT.MAX_MINT() + 1, payment));
-
-        // TODO
-        // LoreumNFT::publicMint() minted >= MAX_SUPPLY || minted + amount > MAX_SUPPLY
-
     }
 
     function test_publicMint_state_full() public {
@@ -215,6 +211,8 @@ contract LoreumNFTTest is Utility, ERC721Holder {
         // Tom (or any minter) is unable to mint additional
         // LoreumNFT::publicMint() minted >= MAX_SUPPLY || minted + amount > MAX_SUPPLY
         assert(!tom.try_publicMint(address(NFT), 1, NFT.mintCost()));
+
+        // TODO: Check minted + amount > MAX_SUPPLY (i.e. 9999 minted, and mintAmount == 2)!
     }
 
 }

--- a/test/LoreumNFT.t.sol
+++ b/test/LoreumNFT.t.sol
@@ -142,10 +142,8 @@ contract LoreumNFTTest is Utility, ERC721Holder {
         uint preBalanceMinter = address(tom).balance;
         uint preBalanceOwner = address(NFT.owner()).balance;
 
-
         // publicMint()
         assert(tom.try_publicMint(address(NFT), mintThisMuch, NFT.mintCost()));
-
 
         // Post-state
         uint postBalanceMinter = address(tom).balance;
@@ -159,6 +157,8 @@ contract LoreumNFTTest is Utility, ERC721Holder {
         for (uint8 b = 0; b < mintThisMuch; b++) {
             assertEq(NFT.ownerOf(b + 1), address(tom));
         }
+
+        // TODO: Consider any ERC721Enumerable _beforeTokenTransfer() / _afterTokenTransfer() state changes
     }
 
     function test_publicMint_restrictions() public {

--- a/test/LoreumNFT.t.sol
+++ b/test/LoreumNFT.t.sol
@@ -180,6 +180,7 @@ contract LoreumNFTTest is Utility, ERC721Holder {
 
     function test_publicMint_state_full() public {
 
+
         // NOTE: type(uint160) required for address(uint160) typecasting below
         uint160 addressID = 55;
 
@@ -198,6 +199,7 @@ contract LoreumNFTTest is Utility, ERC721Holder {
                 minter.transfer(NFT.MAX_MINT() * NFT.mintCost());
             }
             hevm.startPrank(minter);
+            // NOTE: This test will revert if NFT.MAX_SUPPLY() % NFT.MAX_MINT != 0
             NFT.publicMint{value: NFT.mintCost() * NFT.MAX_MINT()}(NFT.MAX_MINT());
             hevm.stopPrank();
         }

--- a/test/LoreumNFT.t.sol
+++ b/test/LoreumNFT.t.sol
@@ -35,8 +35,7 @@ contract LoreumNFTTest is Utility, ERC721Holder {
         // Fund "tom" for minting expenses
         payable(address(tom)).transfer(100 ether);
 
-        // We define this variable here after deployCore() 
-        // in order to instantiate the actor "god"
+        // We define this variable here after deployCore() in order to instantiate the actor "god"
         admin = address(god);
 
         NFT = new LoreumNFT(
@@ -181,7 +180,8 @@ contract LoreumNFTTest is Utility, ERC721Holder {
 
     function test_publicMint_state_full() public {
 
-        uint160 addressID = 55;  // NOTE: type(uint160) required for address(uint160) typecasting below
+        // NOTE: type(uint160) required for address(uint160) typecasting below
+        uint160 addressID = 55;
 
         address payable minter = payable(address(addressID));
         minter.transfer(NFT.MAX_MINT() * NFT.mintCost());
@@ -202,7 +202,7 @@ contract LoreumNFTTest is Utility, ERC721Holder {
             hevm.stopPrank();
         }
 
-        // Post-state.
+        // Post-state
 
         // NFT "Mint" concludes when totalSupply() == MAX_SUPPLY()
         assertEq(NFT.totalSupply(), NFT.MAX_SUPPLY());

--- a/test/LoreumNFT.t.sol
+++ b/test/LoreumNFT.t.sol
@@ -1,17 +1,17 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.16;
 
-// Utility import.
+// Utility import
 import "test/utilities/Utility.sol";
 
-// NFT contract import(s).
+// NFT contract import(s)
 import "src/LoreumNFT.sol";
  
 contract LoreumNFTTest is Utility {
 
     LoreumNFT NFT;
 
-    // Initial NFT settings.
+    // Initial NFT settings
     string public name = "LoreumNFT";
     string public symbol = "LOREUM";
     string public tokenUri = "ipfs://bafybeia4ba2mxk3dzdhu2kaqeh5svu244qmcwbkhm56e2nz4pnuqfake4q/";
@@ -21,21 +21,21 @@ contract LoreumNFTTest is Utility {
     uint16 public maxSupply = 10000;
     uint8 public maxMint = 5;
 
-    address admin;      /// @dev Defined in the setUp() function.
+    address admin;      /// @dev Defined in the setUp() function
 
 
 
     // Initial setUp() function, runs before every test_*.
     function setUp() public {
         
-        // Create actors and tokens.
+        // Create actors and tokens
         deployCore();
         
-        // Fund "tom" for minting expenses.
+        // Fund "tom" for minting expenses
         payable(address(tom)).transfer(100 ether);
 
         // We define this variable here after deployCore() 
-        // in order to instantiate the actor "god".
+        // in order to instantiate the actor "god"
         admin = address(god);
 
         NFT = new LoreumNFT(
@@ -51,10 +51,9 @@ contract LoreumNFTTest is Utility {
 
     }
 
-    // Validate NFT contract constructor() and deployment.
     function test_LoreumNFT_initial_state(uint128 salePrice) public {
 
-        // Initial constructor() parameters.
+        // Initial constructor() parameters
         assertEq(NFT.name(), name);
         assertEq(NFT.symbol(), symbol);
         assertEq(NFT.tokenUri(), "ipfs://bafybeia4ba2mxk3dzdhu2kaqeh5svu244qmcwbkhm56e2nz4pnuqfake4q/");
@@ -93,11 +92,27 @@ contract LoreumNFTTest is Utility {
     }
 
     function test_transferOwnership_state() public {
-        // TODO
+        
+        address currentOwner = NFT.owner();
+        address newOwner = address(42);
+
+        // transferOwnership()
+        assert(god.try_transferOwnership(address(NFT), newOwner));
+
+        // Post-state
+        assertEq(NFT.owner(), newOwner);
+        (address royaltyReceiver, ) = NFT.royaltyInfo(0, 1 ether);
+        assertEq(royaltyReceiver, newOwner);
+
     }
 
     function test_transferOwnership_restrictions() public {
+
+        // onlyOwner
         assert(!ass.try_transferOwnership(address(NFT), address(ass)));
+
+        // newOwner != address(0)
+        assert(!god.try_transferOwnership(address(NFT), address(0)));
     }
 
 
@@ -108,10 +123,10 @@ contract LoreumNFTTest is Utility {
     
     function test_updateMintCost_state_changes(uint256 newCost) public {
 
-        // updateMintCost().
+        // updateMintCost()
         assert(god.try_updateMintCost(address(NFT), newCost));
 
-        // Post-state.
+        // Post-state
         assertEq(NFT.mintCost(), newCost);
     }
 
@@ -123,16 +138,16 @@ contract LoreumNFTTest is Utility {
 
         uint8 mintThisMuch = amountToMint % 5 + 1;
 
-        // Pre-state.
+        // Pre-state
         uint preBalanceMinter = address(tom).balance;
         uint preBalanceOwner = address(NFT.owner()).balance;
 
 
-        // publicMint().
+        // publicMint()
         tom.try_publicMint(address(NFT), mintThisMuch, NFT.mintCost());
 
 
-        // Post-state.
+        // Post-state
         uint postBalanceMinter = address(tom).balance;
         uint postBalanceOwner = address(NFT.owner()).balance;
 

--- a/test/utilities/Utility.sol
+++ b/test/utilities/Utility.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.16;
 
 // User imports.

--- a/test/utilities/actors/Admin.sol
+++ b/test/utilities/actors/Admin.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.16;
 pragma experimental ABIEncoderV2;
 
@@ -17,6 +17,11 @@ contract Admin {
     function try_updateMintCost(address NFT, uint256 amount) external returns (bool ok) {
         string memory sig = "updateMintCost(uint256)";
         (ok,) = address(NFT).call(abi.encodeWithSignature(sig, amount));
+    }
+
+    function try_transferOwnership(address NFT, address newOwner) external returns (bool ok) {
+        string memory sig = "transferOwnership(address)";
+        (ok,) = address(NFT).call(abi.encodeWithSignature(sig, newOwner));
     }
 
 }

--- a/test/utilities/actors/Blackhat.sol
+++ b/test/utilities/actors/Blackhat.sol
@@ -13,4 +13,9 @@ contract Blackhat {
         (ok,) = address(NFT).call(abi.encodeWithSignature(sig, amount));
     }
 
+    function try_transferOwnership(address NFT, address newOwner) external returns (bool ok) {
+        string memory sig = "transferOwnership(address)";
+        (ok,) = address(NFT).call(abi.encodeWithSignature(sig, newOwner));
+    }
+
 }

--- a/test/utilities/actors/Blackhat.sol
+++ b/test/utilities/actors/Blackhat.sol
@@ -18,4 +18,9 @@ contract Blackhat {
         (ok,) = address(NFT).call(abi.encodeWithSignature(sig, newOwner));
     }
 
+    function try_publicMint(address NFT, uint8 amount, uint mintCost) external returns (bool ok) {
+        string memory sig = "publicMint(uint8)";
+        (ok,) = address(NFT).call{value: amount * mintCost}(abi.encodeWithSignature(sig, amount));
+    }
+
 }

--- a/test/utilities/actors/Blackhat.sol
+++ b/test/utilities/actors/Blackhat.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.16;
 pragma experimental ABIEncoderV2;
 

--- a/test/utilities/actors/Minter.sol
+++ b/test/utilities/actors/Minter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.16;
 pragma experimental ABIEncoderV2;
 


### PR DESCRIPTION
This PR accomplishes the following:
- Refactors `SPDX-License-Identifier` from `GPL-3.0-or-later` to `GPL-3.0` for static legally binding contract (in situation where GPL-4.0 is released with unfavorable terms)
- Refactors error messages in `require()` statements to include `LoreumNFT::` as identifier instead of prior `Mintable` or `Owner` (contracts which no longer exist or are no longer present at parent level)
- Removed periods from end of comments in test file
- Extended inheritance of `LoreumNFTTest` to inherit `ERC721Holder` for the purpose of facilitating NFT acquisition via `publicMint()` in the test contract itself, see the scenario test `test_publicMint_state_full`
- Added identifiers over `test_LoreumNFT_initial_state` to indicate which inherited contract within `LoreumNFT` checks are against given lack of transparency of these endpoints exposed from perspective of `LoreumNFT.sol` code
- Extended Users (actors) try functions where appropriate
- Added restriction tests where appropriate
- Segregated `LoreumNFTTest.t.sol` into different sections based on function endpoints with `override` modifier  (inherited) or native endpoints (non-inherited)
- Added two `TODO` comments in test suite for unique edge-cases to examine later and validate
- `LoreumNFT` now inherits `ReentrancyGuard` from open-zeppelin and adds the modifier `nonReentrant` to the function `publicMint()` in response to detectors from Slither (static-analysis)