### PR TITLE
fix: oz ownable out of date, fix v4.9

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,4 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
+	branch = release-v4.9

--- a/src/LoreumNFT.sol
+++ b/src/LoreumNFT.sol
@@ -49,7 +49,7 @@ contract LoreumNFT is ERC2981, ERC721Enumerable, Ownable, ReentrancyGuard {
         uint16 maxSupply_,
         uint8 maxMint_,
         address admin
-    ) Ownable(_msgSender()) ERC721(name_, symbol_) {
+    ) Ownable() ERC721(name_, symbol_) {
         // Initial assignment of state variables.
         tokenUri = tokenUri_;
         mintCost = mintCost_;


### PR DESCRIPTION
Fixes the broken Ownable.sol constructor and sets the submodule version to v4.9 to prevent future breaking changes.